### PR TITLE
fix x11-windows and captionbar are not synchronized during window scaling

### DIFF
--- a/services/surfaceflinger/FrontEnd/LayerSnapshot.h
+++ b/services/surfaceflinger/FrontEnd/LayerSnapshot.h
@@ -48,6 +48,7 @@ struct LayerSnapshot : public compositionengine::LayerFECompositionState {
     LayerSnapshot() = default;
     LayerSnapshot(const RequestedLayerState&, const LayerHierarchy::TraversalPath&);
 
+    const LayerSnapshot* mParentSnapshot;
     LayerHierarchy::TraversalPath path;
     size_t globalZ = std::numeric_limits<ssize_t>::max();
     bool invalidTransform = false;

--- a/services/surfaceflinger/FrontEnd/LayerSnapshotBuilder.cpp
+++ b/services/surfaceflinger/FrontEnd/LayerSnapshotBuilder.cpp
@@ -41,6 +41,7 @@
 float mRealActivityWidth = 0.0;
 std::string mTopPackageName;
 std::string mCaptionName;
+std::string mTaskName;
 bool mEnableCaptionSync = true;
 // [openfde end]
 
@@ -453,10 +454,13 @@ void LayerSnapshotBuilder::updateSnapshots(const Args& args) {
     property_get("com.fde.top_package_name", top_package_name, "");
     char caption_name[PROPERTY_VALUE_MAX];
     property_get("com.fde.caption_name", caption_name, "");
+    char task_name[PROPERTY_VALUE_MAX];
+    property_get("com.fde.task_name", task_name, "");
     char enable_caption_sync[PROPERTY_VALUE_MAX];
     property_get("persist.debug.caption_sync", enable_caption_sync, "true");
 
     mCaptionName = caption_name;
+    mTaskName = task_name;
     mTopPackageName = top_package_name;
     if (strcasecmp(enable_caption_sync, "true") != 0) {
         mEnableCaptionSync = false;
@@ -737,6 +741,7 @@ void LayerSnapshotBuilder::updateSnapshot(LayerSnapshot& snapshot, const Args& a
              RequestedLayerState::Changes::AffectsChildren | RequestedLayerState::Changes::Input |
              RequestedLayerState::Changes::FrameRate | RequestedLayerState::Changes::GameMode);
     snapshot.changes |= parentChanges;
+    snapshot.mParentSnapshot = &parentSnapshot;
     if (args.displayChanges) snapshot.changes |= RequestedLayerState::Changes::Geometry;
     snapshot.reachablilty = LayerSnapshot::Reachablilty::Reachable;
     snapshot.clientChanges |= (parentSnapshot.clientChanges & layer_state_t::AFFECTS_CHILDREN);
@@ -1024,38 +1029,67 @@ void LayerSnapshotBuilder::updateLayerBounds(LayerSnapshot& snapshot,
     // [openfde add] fix caption and window are not synchronized when window is scaling
     if (mEnableCaptionSync) {
         std::string snapshot_name(snapshot.name);
-        FloatRect mActivityCrop;
-        bool hasWallpaperLayer = false;
-        if (!mCaptionName.empty() && snapshot_name.find(mCaptionName) != std::string::npos) {
+        std::string app_class_name = "";
+        float taskLayerWidth = 0.0;
+        bool isWallpaperLayer = false;
+        bool isMutliLayerWindows = false;
+        bool isPackageLayer = (!mTopPackageName.empty() && snapshot_name.starts_with(mTopPackageName));
+        bool isCaptionLayer = (!mCaptionName.empty() && snapshot_name.find(mCaptionName) != std::string::npos);
+        if (isPackageLayer || isCaptionLayer) {
             mRealActivityWidth = 0.0;
-            forEachVisibleSnapshot([&](const frontend::LayerSnapshot& snapshot) {
-                if (snapshot.hasSomethingToDraw()) {
-                    if (snapshot.name.find(mTopPackageName) != std::string::npos) {
-                        mRealActivityWidth += snapshot.geomLayerBounds.right;
+            forEachSnapshot([&](const LayerSnapshot& mSnapshot) {
+                if (mSnapshot.name.starts_with(mTopPackageName)
+                        || mSnapshot.name.starts_with("com.android.wallpaper")) {
+                    bool found = false;
+                    const LayerSnapshot* tmpSnapShot = &mSnapshot;
+                    while (tmpSnapShot->mParentSnapshot != nullptr) {
+                        // find out if the app window is in the same parent layer as the captionbar
+                        if (tmpSnapShot->mParentSnapshot->name.starts_with(mTaskName)) {
+                            taskLayerWidth = tmpSnapShot->mParentSnapshot->geomLayerBounds.right;
+                            found = true;
+                            break;
+                        }
+                        tmpSnapShot = tmpSnapShot->mParentSnapshot;
                     }
-                    if (snapshot.name.find("com.android.wallpaper") != std::string::npos) {
-                        hasWallpaperLayer = true;
+                    if (found) {
+                        app_class_name =  mSnapshot.name.substr(mSnapshot.name.find("/") + 1);
+                        if (app_class_name == "") {
+                            app_class_name = mSnapshot.name;
+                        }
+                        // when app have mutli-windows, set the flag.
+                        if (mRealActivityWidth > 0) {
+                            isMutliLayerWindows = true;
+                        }
+                        mRealActivityWidth += mSnapshot.geomLayerBounds.right;
+                        // when mRealActivityWidth is greater than the parent layer width, reset it.
+                        if (mRealActivityWidth > taskLayerWidth) {
+                            isMutliLayerWindows = false;
+                            mRealActivityWidth = 0;
+                        }
+                        if (mSnapshot.name.find("com.android.wallpaper") != std::string::npos) {
+                            isWallpaperLayer = true;
+                        }
                     }
                 }
             });
 
-            if (hasWallpaperLayer) {
+            if (isWallpaperLayer) {
                 mRealActivityWidth = 0;
             }
 
-            if (mRealActivityWidth > 0) {
-                mActivityCrop = snapshot.geomLayerBounds;
+            if (isCaptionLayer && mRealActivityWidth > 0) {
+                FloatRect mActivityCrop = snapshot.geomLayerBounds;
                 mActivityCrop.right = mRealActivityWidth - 1;
                 snapshot.geomLayerBounds = snapshot.geomLayerBounds.intersect(mActivityCrop);
-                // mRealActivityWidth cant be greater than the parent layout width
-                if (snapshot.geomLayerBounds.right != mActivityCrop.right) {
-                    mRealActivityWidth = 0;
-                }
             }
 
-            if (!mTopPackageName.empty()) {
+            if (isPackageLayer) {
                 // notify CaptionWindowDecoration to set an appropriate Buffer size
-                property_set("com.fde.package_with_caption", mTopPackageName.c_str());
+                if (app_class_name != "" && !isMutliLayerWindows) {
+                    property_set("com.fde.package_with_caption", app_class_name.c_str());
+                } else {
+                    property_set("com.fde.package_with_caption", mTopPackageName.c_str());
+                }
                 std::string data = std::to_string(static_cast<int>(mRealActivityWidth));
                 property_set("com.fde.caption_width", data.c_str());
             }
@@ -1203,6 +1237,14 @@ void LayerSnapshotBuilder::forEachVisibleSnapshot(const ConstVisitor& visitor) c
     for (int i = 0; i < mNumInterestingSnapshots; i++) {
         LayerSnapshot& snapshot = *mSnapshots[(size_t)i];
         if (!snapshot.isVisible) continue;
+        visitor(snapshot);
+    }
+}
+
+void LayerSnapshotBuilder::forEachSnapshot(const ConstVisitor& visitor) const {
+    for (int i = 0; i < mNumInterestingSnapshots; i++) {
+        LayerSnapshot& snapshot = *mSnapshots[(size_t)i];
+        if (!snapshot.hasSomethingToDraw()) continue;
         visitor(snapshot);
     }
 }

--- a/services/surfaceflinger/FrontEnd/LayerSnapshotBuilder.h
+++ b/services/surfaceflinger/FrontEnd/LayerSnapshotBuilder.h
@@ -85,6 +85,7 @@ public:
     typedef std::function<void(std::unique_ptr<LayerSnapshot>& snapshot)> Visitor;
     // Visit each visible snapshot in z-order and move the snapshot if needed
     void forEachVisibleSnapshot(const Visitor& visitor);
+    void forEachSnapshot(const ConstVisitor& visitor) const;
 
     // Visit each snapshot interesting to input reverse z-order
     void forEachInputSnapshot(const ConstVisitor& visitor) const;


### PR DESCRIPTION
解决X11 Linux应用窗口与标题栏宽度不一致的问题，解决缩放过程中标题栏宽度出现抖动的问题
解决方案：
1.增加应用窗口是否与标题栏窗口在同一个父布局的判断逻辑，如果当前窗口与标题栏处于同一个父窗口下，则计算该窗口的宽度，否则丢弃，防止一个应用启动多个窗口导致窗口宽度重复计算的问题
2.优化标题栏宽度同步的时机，更新prop属性提前到应用窗口Bounds设置时，防止shell进程获取的captionbar宽度数据过旧导致的抖动问题

依赖提交：https://github.com/openfde/lineageos_android_frameworks_base/pull/102