### PR TITLE
fix captionbar appears too short when adjusting brightness in Settings

### DIFF
--- a/services/surfaceflinger/FrontEnd/LayerSnapshotBuilder.cpp
+++ b/services/surfaceflinger/FrontEnd/LayerSnapshotBuilder.cpp
@@ -1039,7 +1039,8 @@ void LayerSnapshotBuilder::updateLayerBounds(LayerSnapshot& snapshot,
         bool isMutliLayerWindows = false;
         bool isPackageLayer = (!mTopPackageName.empty() && snapshot_name.starts_with(mTopPackageName));
         bool isCaptionLayer = (!mCaptionName.empty() && snapshot_name.find(mCaptionName) != std::string::npos);
-        if (isPackageLayer || isCaptionLayer) {
+        if ((isPackageLayer || isCaptionLayer)
+                && !mTopPackageName.starts_with("com.android.systemui")) {
             mRealActivityWidth = 0.0;
             forEachSnapshot([&](const LayerSnapshot& mSnapshot) {
                 if (mSnapshot.name.starts_with(mTopPackageName)


### PR DESCRIPTION
解决设置应用修改屏幕亮度时，标题栏显示过短的问题

原因：点击亮度时，会弹出systemui的控件，此时顶层activity会变更为systemui，导致计算应用窗口会遗漏掉左侧setting应用窗口，出现标题栏显示过短的问题

解决方案：针对此情况，只能屏蔽掉systemui在顶层显示时的标题栏同步机制