### PR TITLE
fix captionbar apperas too short when set app permission in settings

### DIFF
--- a/services/surfaceflinger/FrontEnd/LayerSnapshotBuilder.cpp
+++ b/services/surfaceflinger/FrontEnd/LayerSnapshotBuilder.cpp
@@ -1040,11 +1040,11 @@ void LayerSnapshotBuilder::updateLayerBounds(LayerSnapshot& snapshot,
         bool isPackageLayer = (!mTopPackageName.empty() && snapshot_name.starts_with(mTopPackageName));
         bool isCaptionLayer = (!mCaptionName.empty() && snapshot_name.find(mCaptionName) != std::string::npos);
         if ((isPackageLayer || isCaptionLayer)
-                && !mTopPackageName.starts_with("com.android.systemui")) {
+                && !mTopPackageName.starts_with("com.android.systemui")
+                && !mTopPackageName.starts_with("com.android.permissioncontroller")) {
             mRealActivityWidth = 0.0;
             forEachSnapshot([&](const LayerSnapshot& mSnapshot) {
-                if (mSnapshot.name.starts_with(mTopPackageName)
-                        || mSnapshot.name.starts_with("com.android.wallpaper")) {
+                if (mSnapshot.name.starts_with(mTopPackageName)) {
                     bool found = false;
                     const LayerSnapshot* tmpSnapShot = &mSnapshot;
                     while (tmpSnapShot->mParentSnapshot != nullptr) {
@@ -1069,7 +1069,6 @@ void LayerSnapshotBuilder::updateLayerBounds(LayerSnapshot& snapshot,
                         // when mRealActivityWidth is greater than the parent layer width, reset it.
                         if (mRealActivityWidth > taskLayerWidth && taskLayerWidth > 0) {
                             isMutliLayerWindows = false;
-                            mRealActivityWidth = 0;
                         }
                         if (mSnapshot.name.find("com.android.wallpaper") != std::string::npos) {
                             isWallpaperLayer = true;


### PR DESCRIPTION
解决设置->应用->默认应用界面标题栏宽度显示过短的问题，解决同时存在3个以上同名图层时标题栏显示过短的问题