### PR TITLE
fix captionbar appears too long when srceenrecording

### DIFF
--- a/services/surfaceflinger/FrontEnd/LayerSnapshotBuilder.cpp
+++ b/services/surfaceflinger/FrontEnd/LayerSnapshotBuilder.cpp
@@ -1066,16 +1066,18 @@ void LayerSnapshotBuilder::updateLayerBounds(LayerSnapshot& snapshot,
                             isMutliLayerWindows = true;
                         }
                         mRealActivityWidth += mSnapshot.geomLayerBounds.right;
-                        // when mRealActivityWidth is greater than the parent layer width, reset it.
-                        if (mRealActivityWidth > taskLayerWidth && taskLayerWidth > 0) {
-                            isMutliLayerWindows = false;
-                        }
                         if (mSnapshot.name.find("com.android.wallpaper") != std::string::npos) {
                             isWallpaperLayer = true;
                         }
                     }
                 }
             });
+
+            // when mRealActivityWidth is greater than the parent layer width, reset it.
+            if (mRealActivityWidth > taskLayerWidth && taskLayerWidth > 0) {
+                isMutliLayerWindows = false;
+                mRealActivityWidth = 0;
+            }
 
             if (isWallpaperLayer || (mDisplayWidth > 0 && mRealActivityWidth > mDisplayWidth)) {
                 mRealActivityWidth = 0;


### PR DESCRIPTION
解决录屏的时候标题栏宽度显示异常的问题

原因：录屏的时候，打开停止按钮时，会增加一个控件图层，该图层会计算到标题栏宽度中，从而导致异常

解决：在计算标题栏宽度后，再判断一次与最顶层的父图层宽度，如果超过该父图层宽度，则丢弃本次修改