### PR TITLE
fix incorrect recording area for a single application

### DIFF
--- a/libs/gui/LayerState.cpp
+++ b/libs/gui/LayerState.cpp
@@ -61,6 +61,8 @@ layer_state_t::layer_state_t()
         what(0),
         x(0),
         y(0),
+        mirror_x(0),
+        mirror_y(0),
         z(0),
         flags(0),
         mask(0),
@@ -106,6 +108,8 @@ status_t layer_state_t::write(Parcel& output) const
     SAFE_PARCEL(output.writeUint64, what);
     SAFE_PARCEL(output.writeFloat, x);
     SAFE_PARCEL(output.writeFloat, y);
+    SAFE_PARCEL(output.writeFloat, mirror_x);
+    SAFE_PARCEL(output.writeFloat, mirror_y);
     SAFE_PARCEL(output.writeInt32, z);
     SAFE_PARCEL(output.writeUint32, layerStack.id);
     SAFE_PARCEL(output.writeUint32, flags);
@@ -210,6 +214,8 @@ status_t layer_state_t::read(const Parcel& input)
     SAFE_PARCEL(input.readUint64, &what);
     SAFE_PARCEL(input.readFloat, &x);
     SAFE_PARCEL(input.readFloat, &y);
+    SAFE_PARCEL(input.readFloat, &mirror_x);
+    SAFE_PARCEL(input.readFloat, &mirror_y);
     SAFE_PARCEL(input.readInt32, &z);
     SAFE_PARCEL(input.readUint32, &layerStack.id);
 
@@ -532,6 +538,11 @@ void layer_state_t::merge(const layer_state_t& other) {
         x = other.x;
         y = other.y;
     }
+    if (other.what & eMirrorPositionChanged) {
+        what |= eMirrorPositionChanged;
+        mirror_x = other.mirror_x;
+        mirror_y = other.mirror_y;
+    }
     if (other.what & eLayerChanged) {
         what |= eLayerChanged;
         what &= ~eRelativeLayerChanged;
@@ -744,6 +755,7 @@ void layer_state_t::merge(const layer_state_t& other) {
 uint64_t layer_state_t::diff(const layer_state_t& other) const {
     uint64_t diff = 0;
     CHECK_DIFF2(diff, ePositionChanged, other, x, y);
+    CHECK_DIFF2(diff, eMirrorPositionChanged, other, mirror_x, mirror_y);
     if (other.what & eLayerChanged) {
         diff |= eLayerChanged;
         diff &= ~eRelativeLayerChanged;

--- a/libs/gui/SurfaceComposerClient.cpp
+++ b/libs/gui/SurfaceComposerClient.cpp
@@ -1372,6 +1372,21 @@ SurfaceComposerClient::Transaction& SurfaceComposerClient::Transaction::setPosit
     return *this;
 }
 
+SurfaceComposerClient::Transaction& SurfaceComposerClient::Transaction::setMirrorPosition(
+        const sp<SurfaceControl>& sc, float x, float y) {
+    layer_state_t* s = getLayerState(sc);
+    if (!s) {
+        mStatus = BAD_INDEX;
+        return *this;
+    }
+    s->what |= layer_state_t::eMirrorPositionChanged;
+    s->mirror_x = x;
+    s->mirror_y = y;
+
+    registerSurfaceControlForCallback(sc);
+    return *this;
+}
+
 SurfaceComposerClient::Transaction& SurfaceComposerClient::Transaction::show(
         const sp<SurfaceControl>& sc) {
     return setFlags(sc, 0, layer_state_t::eLayerHidden);

--- a/libs/gui/include/gui/LayerState.h
+++ b/libs/gui/include/gui/LayerState.h
@@ -216,6 +216,7 @@ struct layer_state_t {
         eTrustedOverlayChanged = 0x4000'00000000,
         eDropInputModeChanged = 0x8000'00000000,
         eExtendedRangeBrightnessChanged = 0x10000'00000000,
+        eMirrorPositionChanged = 0x20000'00000000,
     };
 
     layer_state_t();
@@ -305,6 +306,8 @@ struct layer_state_t {
     uint64_t what;
     float x;
     float y;
+    float mirror_x;
+    float mirror_y;
     int32_t z;
     ui::LayerStack layerStack = ui::DEFAULT_LAYER_STACK;
     uint32_t flags;

--- a/libs/gui/include/gui/SurfaceComposerClient.h
+++ b/libs/gui/include/gui/SurfaceComposerClient.h
@@ -516,6 +516,7 @@ public:
         Transaction& show(const sp<SurfaceControl>& sc);
         Transaction& hide(const sp<SurfaceControl>& sc);
         Transaction& setPosition(const sp<SurfaceControl>& sc, float x, float y);
+        Transaction& setMirrorPosition(const sp<SurfaceControl>& sc, float x, float y);
         // b/243180033 remove once functions are not called from vendor code
         Transaction& setSize(const sp<SurfaceControl>&, uint32_t, uint32_t) { return *this; }
         Transaction& setLayer(const sp<SurfaceControl>& sc,

--- a/services/surfaceflinger/FrontEnd/LayerSnapshot.cpp
+++ b/services/surfaceflinger/FrontEnd/LayerSnapshot.cpp
@@ -483,6 +483,10 @@ void LayerSnapshot::merge(const RequestedLayerState& requested, bool forceUpdate
         localTransformInverse = localTransform.inverse();
     }
 
+    if (forceUpdate || requested.what & layer_state_t::eMirrorPositionChanged) {
+        mirrorTransform = requested.getMirrorTransform();
+    }
+
     if (forceUpdate || requested.what & (layer_state_t::eColorChanged) ||
         requested.changes.test(RequestedLayerState::Changes::BufferSize)) {
         color.rgb = requested.getColor().rgb;

--- a/services/surfaceflinger/FrontEnd/LayerSnapshot.h
+++ b/services/surfaceflinger/FrontEnd/LayerSnapshot.h
@@ -81,6 +81,7 @@ struct LayerSnapshot : public compositionengine::LayerFECompositionState {
     ui::Transform localTransformInverse;
     gui::WindowInfo inputInfo;
     ui::Transform localTransform;
+    ui::Transform mirrorTransform;
     gui::DropInputMode dropInputMode;
     bool isTrustedOverlay;
     gui::GameMode gameMode;

--- a/services/surfaceflinger/FrontEnd/LayerSnapshotBuilder.cpp
+++ b/services/surfaceflinger/FrontEnd/LayerSnapshotBuilder.cpp
@@ -928,6 +928,12 @@ void LayerSnapshotBuilder::updateSnapshot(LayerSnapshot& snapshot, const Args& a
         updateInput(snapshot, requested, parentSnapshot, path, args);
     }
 
+    if (forceUpdate || snapshot.clientChanges & layer_state_t::eMirrorPositionChanged) {
+        if (snapshot.mirrorTransform.tx() != 0 || snapshot.mirrorTransform.ty() != 0) {
+            snapshot.geomLayerTransform.set(snapshot.mirrorTransform.tx(), snapshot.mirrorTransform.ty());
+        }
+    }
+
     // computed snapshot properties
     snapshot.forceClientComposition =
             snapshot.shadowSettings.length > 0 || snapshot.stretchEffect.hasEffect();

--- a/services/surfaceflinger/FrontEnd/RequestedLayerState.cpp
+++ b/services/surfaceflinger/FrontEnd/RequestedLayerState.cpp
@@ -109,6 +109,7 @@ RequestedLayerState::RequestedLayerState(const LayerCreationArgs& args)
     hasColorTransform = false;
     bufferTransform = 0;
     requestedTransform.reset();
+    requestedMirrorTransform.reset();
     bufferData = std::make_shared<BufferData>();
     bufferData->frameNumber = 0;
     bufferData->acquireFence = sp<Fence>::make(-1);
@@ -312,6 +313,10 @@ void RequestedLayerState::merge(const ResolvedComposerState& resolvedComposerSta
         requestedTransform.set(x, y);
     }
 
+    if (clientState.what & layer_state_t::eMirrorPositionChanged) {
+        requestedMirrorTransform.set(mirror_x, mirror_y);
+    }
+
     if (clientState.what & layer_state_t::eMatrixChanged) {
         requestedTransform.set(matrix.dsdx, matrix.dtdy, matrix.dtdx, matrix.dsdy);
     }
@@ -392,6 +397,10 @@ ui::Transform RequestedLayerState::getTransform(uint32_t displayRotationFlags) c
     transform.set(sx, 0, 0, sy);
     transform.set(static_cast<float>(destRect.left), static_cast<float>(destRect.top));
     return transform;
+}
+
+ui::Transform RequestedLayerState::getMirrorTransform() const {
+    return requestedMirrorTransform;
 }
 
 std::string RequestedLayerState::getDebugString() const {
@@ -595,7 +604,7 @@ bool RequestedLayerState::isSimpleBufferUpdate(const layer_state_t& s) const {
     }
 
     bool changedFlags = diff(s);
-    static constexpr auto deniedChanges = layer_state_t::ePositionChanged |
+    static constexpr auto deniedChanges = layer_state_t::ePositionChanged | layer_state_t::eMirrorPositionChanged |
             layer_state_t::eAlphaChanged | layer_state_t::eColorTransformChanged |
             layer_state_t::eBackgroundColorChanged | layer_state_t::eMatrixChanged |
             layer_state_t::eCornerRadiusChanged | layer_state_t::eBackgroundBlurRadiusChanged |

--- a/services/surfaceflinger/FrontEnd/RequestedLayerState.h
+++ b/services/surfaceflinger/FrontEnd/RequestedLayerState.h
@@ -65,6 +65,7 @@ struct RequestedLayerState : layer_state_t {
 
     // Currently we only care about the primary display
     ui::Transform getTransform(uint32_t displayRotationFlags) const;
+    ui::Transform getMirrorTransform() const;
     ui::Size getUnrotatedBufferSize(uint32_t displayRotationFlags) const;
     bool canBeDestroyed() const;
     bool isRoot() const;
@@ -109,6 +110,7 @@ struct RequestedLayerState : layer_state_t {
     bool potentialCursor{false};
     bool protectedByApp{false}; // application requires protected path to external sink
     ui::Transform requestedTransform;
+    ui::Transform requestedMirrorTransform;
     std::shared_ptr<FenceTime> acquireFenceTime;
     std::shared_ptr<renderengine::ExternalTexture> externalTexture;
     gui::GameMode gameMode;


### PR DESCRIPTION
解决单应用录屏时，录制区域未正确匹配到应用窗口位置的问题

增加SurfaceControl.Transaction.setMirrorPosition接口，把缩放之后的偏移位置传递给sf，更新mirrorLayer图层的geomLayerTransform属性

依赖提交：https://github.com/openfde/lineageos_android_frameworks_base/pull/131