### PR TITLE
fix captionbar appears too short

### DIFF
--- a/services/surfaceflinger/FrontEnd/LayerSnapshotBuilder.cpp
+++ b/services/surfaceflinger/FrontEnd/LayerSnapshotBuilder.cpp
@@ -466,10 +466,18 @@ void LayerSnapshotBuilder::updateSnapshots(const Args& args) {
     mCaptionName = caption_name;
     mTaskName = task_name;
     mTopPackageName = top_package_name;
+
     if (strcasecmp(enable_caption_sync, "true") != 0) {
         mEnableCaptionSync = false;
     } else {
         mEnableCaptionSync = true;
+    }
+
+    if (mTopPackageName.starts_with("android")
+            || mTopPackageName.starts_with("com.android.gallery3d")
+            || mTopPackageName.starts_with("com.android.systemui")
+            || mTopPackageName.starts_with("com.android.permissioncontroller")) {
+        mEnableCaptionSync = false;
     }
     // [openfde end]
 
@@ -1039,9 +1047,7 @@ void LayerSnapshotBuilder::updateLayerBounds(LayerSnapshot& snapshot,
         bool isMutliLayerWindows = false;
         bool isPackageLayer = (!mTopPackageName.empty() && snapshot_name.starts_with(mTopPackageName));
         bool isCaptionLayer = (!mCaptionName.empty() && snapshot_name.find(mCaptionName) != std::string::npos);
-        if ((isPackageLayer || isCaptionLayer)
-                && !mTopPackageName.starts_with("com.android.systemui")
-                && !mTopPackageName.starts_with("com.android.permissioncontroller")) {
+        if ((isPackageLayer || isCaptionLayer)) {
             mRealActivityWidth = 0.0;
             forEachSnapshot([&](const LayerSnapshot& mSnapshot) {
                 if (mSnapshot.name.starts_with(mTopPackageName)) {

--- a/services/surfaceflinger/FrontEnd/LayerSnapshotBuilder.cpp
+++ b/services/surfaceflinger/FrontEnd/LayerSnapshotBuilder.cpp
@@ -1066,16 +1066,18 @@ void LayerSnapshotBuilder::updateLayerBounds(LayerSnapshot& snapshot,
                             isMutliLayerWindows = true;
                         }
                         mRealActivityWidth += mSnapshot.geomLayerBounds.right;
-                        // when mRealActivityWidth is greater than the parent layer width, reset it.
-                        if (mRealActivityWidth > taskLayerWidth && taskLayerWidth > 0) {
-                            isMutliLayerWindows = false;
-                        }
                         if (mSnapshot.name.find("com.android.wallpaper") != std::string::npos) {
                             isWallpaperLayer = true;
                         }
                     }
                 }
             });
+
+            // when mRealActivityWidth is greater than the parent layer width, reset it.
+            if (mRealActivityWidth > taskLayerWidth && taskLayerWidth > 0) {
+                isMutliLayerWindows = false;
+                mRealActivityWidth = 0;
+            }
 
             if (isWallpaperLayer || (mDisplayWidth > 0 && mRealActivityWidth > mDisplayWidth)) {
                 mRealActivityWidth = 0;


### PR DESCRIPTION
解决设置应用/存储界面打开文件时选择打开方式时标题栏宽度异常的问题，解决设置应用/更换壁纸/选择壁纸页面时标题栏宽度异常的问题

优化判断顶层包名禁用标题栏同步机制的逻辑，从每个图层都需要判断修改到每次更新刷新时判断，可有效降低判断次数