### PR TITLE
fix the geomLayerTransform being overwritten during single applicatin screen recording

### DIFF
--- a/services/surfaceflinger/FrontEnd/LayerSnapshotBuilder.cpp
+++ b/services/surfaceflinger/FrontEnd/LayerSnapshotBuilder.cpp
@@ -1061,6 +1061,9 @@ void LayerSnapshotBuilder::updateLayerBounds(LayerSnapshot& snapshot,
                     bool found = false;
                     const LayerSnapshot* tmpSnapShot = &mSnapshot;
                     while (tmpSnapShot->mParentSnapshot != nullptr) {
+                        if (tmpSnapShot->mParentSnapshot->name == "") {
+                            break;
+                        }
                         // find out if the app window is in the same parent layer as the captionbar
                         if (tmpSnapShot->mParentSnapshot->name.starts_with(mTaskName)) {
                             taskLayerWidth = tmpSnapShot->mParentSnapshot->geomLayerBounds.right;

--- a/services/surfaceflinger/FrontEnd/LayerSnapshotBuilder.cpp
+++ b/services/surfaceflinger/FrontEnd/LayerSnapshotBuilder.cpp
@@ -936,7 +936,8 @@ void LayerSnapshotBuilder::updateSnapshot(LayerSnapshot& snapshot, const Args& a
         updateInput(snapshot, requested, parentSnapshot, path, args);
     }
 
-    if (forceUpdate || snapshot.clientChanges & layer_state_t::eMirrorPositionChanged) {
+    // if (forceUpdate || snapshot.clientChanges & layer_state_t::eMirrorPositionChanged)
+    {
         if (snapshot.mirrorTransform.tx() != 0 || snapshot.mirrorTransform.ty() != 0) {
             snapshot.geomLayerTransform.set(snapshot.mirrorTransform.tx(), snapshot.mirrorTransform.ty());
         }


### PR DESCRIPTION
1.解决单应用录屏时概率性出现录制区域不对的问题
2.解决平行视界下录屏出现sf崩溃的问题

问题1原因：sf在更新layer时会根据父layer重新计算geomLayerTransform导致覆盖掉正确的偏移位置
问题2原因：sf在检索所有图层信息时，会搜索到录屏的layer信息，而RootWrapper的父layer里面的部分变量为空，导致对其赋值时出现非法地址的异常

问题1解决方案：只要应用层设置了偏移位置，则在每次更新该layer时均使用应用设置的Transform
问题2解决方案：针对异常layer跳过处理，不影响实际功能