### PR TITLE
fix tencent.wemeet.app cant share screen in x11 mode

### DIFF
--- a/services/surfaceflinger/DisplayDevice.cpp
+++ b/services/surfaceflinger/DisplayDevice.cpp
@@ -106,6 +106,12 @@ DisplayDevice::DisplayDevice(DisplayDeviceCreationArgs& args)
     }
 
     mCompositionDisplay->getRenderSurface()->initialize();
+    // [openfde add] fix tencent.wemeet.app cant share screen in x11 mode
+    if (isVirtual()) {
+        mCompositionDisplay->getRenderSurface()->setBufferPixelFormat(
+                static_cast<ui::PixelFormat>(HAL_PIXEL_FORMAT_RGBA_8888));
+    }
+    // [openfde end]
 
     setPowerMode(args.initialPowerMode);
 


### PR DESCRIPTION
解决x11模式下腾讯会议无法共享屏幕的问题

原因：在x11模式下，GraphicBuffer格式默认设置为BGRA，而共享屏幕的ImageReader对象设置的格式为RGBA，导致ImageReader校验format失败

解决方案：在创建虚拟屏时，再次设置GraphicBuffer格式为RGBA即可