### PR TITLE
add GRALLOC_USAGE_PRIVATE_0 usage for rgb565 in mesa env

### DIFF
--- a/libs/renderengine/skia/SkiaRenderEngine.cpp
+++ b/libs/renderengine/skia/SkiaRenderEngine.cpp
@@ -1075,13 +1075,15 @@ void SkiaRenderEngine::drawLayersInternal(
 
                         dst_gb = new GraphicBuffer(
                                 width, height, HAL_PIXEL_FORMAT_RGB_565,
-                                GRALLOC_USAGE_HW_TEXTURE | GRALLOC_USAGE_HW_RENDER);
+                                GRALLOC_USAGE_HW_TEXTURE | GRALLOC_USAGE_HW_RENDER
+                                    | GRALLOC_USAGE_PRIVATE_0);
 
                         void* dst_data = nullptr;
                         int dst_result = dst_gb->lock(GRALLOC_USAGE_SW_WRITE_OFTEN, &dst_data);
                         if (dst_result == 0 && dst_data != nullptr) {
                             unsigned char* rgb565 = (unsigned char*) dst_data;
 #if USE_GPU_COVERT
+                            int stride = graphicBuffer->getStride();
                             const native_handle_t* dst_handle = dst_gb->getNativeBuffer()->handle;
                             int rgbFd = dst_handle->data[0];
                             const native_handle_t* src_handle = graphicBuffer->getNativeBuffer()->handle;


### PR DESCRIPTION
1.解决爱奇艺播放视频时偶现花屏的问题
-- 爱奇艺视频使用RGB565格式，之前使用YV12格式转RGB565时，要求对rgb进行256位对齐，而stride要求使用原始width*2，否则合成后显示会异常，爱奇艺解码数据无需转换，故stride无需处理
-- 在YV12转RGB565函数中，对RGB565格式新增GRALLOC_USAGE_PRIVATE_0的usage，gbm对该标志位做甄别处理