### PR TITLE
fix captionbar cant click min/max/close Button

### DIFF
--- a/services/surfaceflinger/FrontEnd/LayerSnapshotBuilder.cpp
+++ b/services/surfaceflinger/FrontEnd/LayerSnapshotBuilder.cpp
@@ -914,6 +914,7 @@ void LayerSnapshotBuilder::updateSnapshot(LayerSnapshot& snapshot, const Args& a
             if (snapshot_name.find(mCaptionName) != std::string::npos) {
                 uint32_t primaryDisplayRotationFlags = getPrimaryDisplayRotationFlags(args.displays);
                 updateLayerBounds(snapshot, requested, parentSnapshot, primaryDisplayRotationFlags);
+                updateInput(snapshot, requested, parentSnapshot, path, args);
             }
         }
         // [openfde end]


### PR DESCRIPTION
解决平行视界下最小化窗口再恢复窗口后无法点击最小化/最大化/关闭按钮的问题

原因是恢复窗口时概率性轮询layer只查找到一个窗口的layer，此时会更新标题栏的input区域，当应用窗口刷新完成后会强制更新一次标题栏layer，此时标题栏会与应用窗口大小保持同步，但是标题栏的input区域没有更新，所以同步更新一次input区域即可