### PR TITLE
fix tiktok play video abnormality

### DIFF
--- a/libs/renderengine/Android.bp
+++ b/libs/renderengine/Android.bp
@@ -132,6 +132,7 @@ cc_library_static {
     ],
     include_dirs: [
         "external/skia/src/gpu",
+        "frameworks/native/libs/nativewindow/include-private/private",
     ],
     lto: {
         thin: true,

--- a/libs/renderengine/skia/SkiaRenderEngine.cpp
+++ b/libs/renderengine/skia/SkiaRenderEngine.cpp
@@ -85,6 +85,7 @@
 #include "system/graphics-base-v1.0.h"
 #include <cutils/properties.h>
 
+#define ALIGN(value, base) (((value) + ((base)-1)) & ~((base)-1))
 namespace {
 
 // Debugging settings
@@ -396,6 +397,11 @@ void SkiaRenderEngine::mapExternalTextureBuffer(const sp<GraphicBuffer>& buffer,
     if (!isThreaded()) {
         return;
     }
+
+    if (buffer->getPixelFormat() == HAL_PIXEL_FORMAT_YV12
+            && buffer->needConvertFormat()) {
+        return ;
+    }
     // We don't attempt to map a buffer if the buffer contains protected content. In GL this is
     // important because GPU resources for protected buffers are much more limited. (In Vk we
     // simply match the existing behavior for protected buffers.)  We also never cache any
@@ -652,6 +658,55 @@ private:
     AutoBackendTexture::CleanupManager& mMgr;
 };
 
+void yv12_to_bgra(const unsigned char* yv12_data, int width, int height, int y_stride,
+                    unsigned char* rgb_output) {
+    int uv_stride = y_stride / 2;
+
+    size_t y_size = y_stride * height;
+    size_t uv_size = uv_stride * (height / 2);
+
+    const uint8_t* y_plane = yv12_data;
+    const uint8_t* v_plane = yv12_data + y_size;
+    const uint8_t* u_plane = v_plane + uv_size;
+
+    const int coef_rv = 359;   // 1.402 * 256
+    const int coef_gu = 88;    // 0.344 * 256
+    const int coef_gv = 183;   // 0.714 * 256
+    const int coef_bu = 454;   // 1.773 * 256
+
+    for (int y = 0; y < height; y++) {
+        const uint8_t* src_y = y_plane + y * y_stride;
+        uint8_t* dst = rgb_output + y * width * 4;
+
+        int uv_y = y / 2;
+        const uint8_t* src_v = v_plane + uv_y * uv_stride;
+        const uint8_t* src_u = u_plane + uv_y * uv_stride;
+
+        for (int x = 0; x < width; x++) {
+            int uv_x = x / 2;
+            int Y = src_y[x];
+            int V = src_v[uv_x];
+            int U = src_u[uv_x];
+
+            int C = Y;
+            int D = U - 128;
+            int E = V - 128;
+
+            int R = (C * 298 + coef_rv * E + 128) >> 8;
+            int G = (C * 298 - coef_gu * D - coef_gv * E + 128) >> 8;
+            int B = (C * 298 + coef_bu * D + 128) >> 8;
+
+            if (R < 0) R = 0; else if (R > 255) R = 255;
+            if (G < 0) G = 0; else if (G > 255) G = 255;
+            if (B < 0) B = 0; else if (B > 255) B = 255;
+
+            dst[4*x + 0] = (uint8_t)B;
+            dst[4*x + 1] = (uint8_t)G;
+            dst[4*x + 2] = (uint8_t)R;
+            dst[4*x + 3] = 0xFF;   // Alpha
+        }
+    }
+}
 void SkiaRenderEngine::drawLayersInternal(
         const std::shared_ptr<std::promise<FenceResult>>&& resultPromise,
         const DisplaySettings& display, const std::vector<LayerSettings>& layers,
@@ -951,10 +1006,50 @@ void SkiaRenderEngine::drawLayersInternal(
 
         SkPaint paint;
         if (layer.source.buffer.buffer) {
+            int srcWidth = 0;
+            int srcHeight = 0;
+            sp<GraphicBuffer> dst_gb;
+            sp<GraphicBuffer> graphicBuffer = layer.source.buffer.buffer->getBuffer();
+            if (graphicBuffer->getPixelFormat() == HAL_PIXEL_FORMAT_YV12) {
+                if (graphicBuffer->needConvertFormat()) {
+                    void* data = nullptr;
+                    int result = graphicBuffer->lock(GRALLOC_USAGE_SW_READ_OFTEN, &data);
+                    if (result == 0 && data != nullptr) {
+                        unsigned char* yuv_data = (unsigned char*)data;
+                        int width = graphicBuffer->getWidth();
+                        int height = graphicBuffer->getHeight();
+                        int stride = graphicBuffer->getStride();
+
+                        srcWidth = width;
+                        srcHeight = height;
+                        width = ALIGN(width, 64);
+
+                        dst_gb = new GraphicBuffer(
+                                width, height, HAL_PIXEL_FORMAT_BGRA_8888,
+                                GRALLOC_USAGE_HW_TEXTURE | GRALLOC_USAGE_HW_RENDER
+                                    | GRALLOC_USAGE_PRIVATE_0);
+
+                        void* dst_data = nullptr;
+                        int dst_result = dst_gb->lock(GRALLOC_USAGE_SW_WRITE_OFTEN, &dst_data);
+                        if (dst_result == 0 && dst_data != nullptr) {
+                            unsigned char* bgra = (unsigned char*) dst_data;
+                            yv12_to_bgra(yuv_data, width, height, stride, bgra);
+                        }
+                        if (dst_gb != NULL) {
+                            dst_gb->unlock();
+                        }
+                        graphicBuffer->unlock();
+                    }
+                }
+            }
             ATRACE_NAME("DrawImage");
             validateInputBufferUsage(layer.source.buffer.buffer->getBuffer());
             const auto& item = layer.source.buffer;
-            auto imageTextureRef = getOrCreateBackendTexture(item.buffer->getBuffer(), false);
+            sp<GraphicBuffer> layer_gb = item.buffer->getBuffer();
+            if (dst_gb != NULL) {
+                layer_gb = dst_gb;
+            }
+            auto imageTextureRef = getOrCreateBackendTexture(layer_gb, false);
 
             // if the layer's buffer has a fence, then we must must respect the fence prior to using
             // the buffer.
@@ -990,7 +1085,12 @@ void SkiaRenderEngine::drawLayersInternal(
             // building the total matrix with the textureTransform we need to first
             // normalize it, then apply the textureTransform, then scale back up.
             texMatrix.preScale(1.0f / bounds.width(), 1.0f / bounds.height());
-            texMatrix.postScale(image->width(), image->height());
+            if (layer_gb->getUsage() & GRALLOC_USAGE_PRIVATE_0) {
+                texMatrix.postScale(srcWidth, srcHeight);
+            } else {
+                texMatrix.postScale(image->width(), image->height());
+            }
+
 
             SkMatrix matrix;
             if (!texMatrix.invert(&matrix)) {

--- a/libs/ui/Gralloc2.cpp
+++ b/libs/ui/Gralloc2.cpp
@@ -194,6 +194,23 @@ void Gralloc2Mapper::freeBuffer(buffer_handle_t bufferHandle) const {
             buffer, error);
 }
 
+int Gralloc2Mapper::needConvertFormat(buffer_handle_t bufferHandle) const {
+    Error error;
+    int result = 0;
+    auto buffer = const_cast<native_handle_t*>(bufferHandle);
+    auto ret = mMapper->needConvertFormat(buffer,
+            [&](const auto& tmpError, const auto& tmpBuffer)
+            {
+                error = tmpError;
+                if (error != Error::NONE) {
+                    return 0;
+                }
+                result = tmpBuffer;
+                return 0;
+            });
+    return (ret.isOk() ? result : 0);
+}
+
 status_t Gralloc2Mapper::validateBufferSize(buffer_handle_t bufferHandle, uint32_t width,
                                             uint32_t height, android::PixelFormat format,
                                             uint32_t layerCount, uint64_t usage,

--- a/libs/ui/Gralloc3.cpp
+++ b/libs/ui/Gralloc3.cpp
@@ -167,6 +167,11 @@ void Gralloc3Mapper::freeBuffer(buffer_handle_t bufferHandle) const {
     ALOGE_IF(error != Error::NONE, "freeBuffer(%p) failed with %d", buffer, error);
 }
 
+int Gralloc3Mapper::needConvertFormat(buffer_handle_t bufferHandle) const {
+    (void)bufferHandle;
+    return 0;
+}
+
 status_t Gralloc3Mapper::validateBufferSize(buffer_handle_t bufferHandle, uint32_t width,
                                             uint32_t height, android::PixelFormat format,
                                             uint32_t layerCount, uint64_t usage,

--- a/libs/ui/Gralloc4.cpp
+++ b/libs/ui/Gralloc4.cpp
@@ -227,6 +227,11 @@ void Gralloc4Mapper::freeBuffer(buffer_handle_t bufferHandle) const {
     ALOGE_IF(error != Error::NONE, "freeBuffer(%p) failed with %d", buffer, error);
 }
 
+int Gralloc4Mapper::needConvertFormat(buffer_handle_t bufferHandle) const {
+    (void)bufferHandle;
+    return 0;
+}
+
 status_t Gralloc4Mapper::validateBufferSize(buffer_handle_t bufferHandle, uint32_t width,
                                             uint32_t height, PixelFormat format,
                                             uint32_t layerCount, uint64_t usage,

--- a/libs/ui/Gralloc5.cpp
+++ b/libs/ui/Gralloc5.cpp
@@ -535,6 +535,11 @@ void Gralloc5Mapper::freeBuffer(buffer_handle_t bufferHandle) const {
     mMapper->v5.freeBuffer(bufferHandle);
 }
 
+int Gralloc5Mapper::needConvertFormat(buffer_handle_t bufferHandle) const {
+    (void)bufferHandle;
+    return 0;
+}
+
 status_t Gralloc5Mapper::validateBufferSize(buffer_handle_t bufferHandle, uint32_t width,
                                             uint32_t height, PixelFormat format,
                                             uint32_t layerCount, uint64_t usage,

--- a/libs/ui/GraphicBuffer.cpp
+++ b/libs/ui/GraphicBuffer.cpp
@@ -233,6 +233,14 @@ bool GraphicBuffer::needsReallocation(uint32_t inWidth, uint32_t inHeight,
     return false;
 }
 
+int GraphicBuffer::needConvertFormat()
+{
+    if (ANativeWindowBuffer::handle != nullptr) {
+        return getBufferMapper().needConvertFormat(ANativeWindowBuffer::handle);
+    }
+    return 0;
+}
+
 status_t GraphicBuffer::initWithSize(uint32_t inWidth, uint32_t inHeight,
         PixelFormat inFormat, uint32_t inLayerCount, uint64_t inUsage,
         std::string requestorName)

--- a/libs/ui/GraphicBufferMapper.cpp
+++ b/libs/ui/GraphicBufferMapper.cpp
@@ -139,6 +139,13 @@ status_t GraphicBufferMapper::freeBuffer(buffer_handle_t handle)
     return NO_ERROR;
 }
 
+int GraphicBufferMapper::needConvertFormat(buffer_handle_t handle)
+{
+    ATRACE_CALL();
+
+    return mMapper->needConvertFormat(handle);
+}
+
 ui::Result<LockResult> GraphicBufferMapper::lock(buffer_handle_t handle, int64_t usage,
                                                  const Rect& bounds, unique_fd&& acquireFence) {
     ATRACE_CALL();

--- a/libs/ui/include/ui/Gralloc.h
+++ b/libs/ui/include/ui/Gralloc.h
@@ -49,6 +49,8 @@ public:
 
     virtual void freeBuffer(buffer_handle_t bufferHandle) const = 0;
 
+    virtual int needConvertFormat(buffer_handle_t rawHandle) const = 0;
+
     virtual status_t validateBufferSize(buffer_handle_t bufferHandle, uint32_t width,
                                         uint32_t height, android::PixelFormat format,
                                         uint32_t layerCount, uint64_t usage,

--- a/libs/ui/include/ui/Gralloc2.h
+++ b/libs/ui/include/ui/Gralloc2.h
@@ -45,6 +45,8 @@ public:
 
     void freeBuffer(buffer_handle_t bufferHandle) const override;
 
+    int needConvertFormat(buffer_handle_t rawHandle) const override;
+
     status_t validateBufferSize(buffer_handle_t bufferHandle, uint32_t width, uint32_t height,
                                 android::PixelFormat format, uint32_t layerCount, uint64_t usage,
                                 uint32_t stride) const override;

--- a/libs/ui/include/ui/Gralloc3.h
+++ b/libs/ui/include/ui/Gralloc3.h
@@ -44,6 +44,8 @@ public:
 
     void freeBuffer(buffer_handle_t bufferHandle) const override;
 
+    int needConvertFormat(buffer_handle_t rawHandle) const override;
+
     status_t validateBufferSize(buffer_handle_t bufferHandle, uint32_t width, uint32_t height,
                                 android::PixelFormat format, uint32_t layerCount, uint64_t usage,
                                 uint32_t stride) const override;

--- a/libs/ui/include/ui/Gralloc4.h
+++ b/libs/ui/include/ui/Gralloc4.h
@@ -49,6 +49,8 @@ public:
 
     void freeBuffer(buffer_handle_t bufferHandle) const override;
 
+    int needConvertFormat(buffer_handle_t rawHandle) const override;
+
     status_t validateBufferSize(buffer_handle_t bufferHandle, uint32_t width, uint32_t height,
                                 PixelFormat format, uint32_t layerCount, uint64_t usage,
                                 uint32_t stride) const override;

--- a/libs/ui/include/ui/Gralloc5.h
+++ b/libs/ui/include/ui/Gralloc5.h
@@ -40,6 +40,8 @@ public:
 
     void freeBuffer(buffer_handle_t bufferHandle) const override;
 
+    int needConvertFormat(buffer_handle_t rawHandle) const override;
+
     [[nodiscard]] status_t validateBufferSize(buffer_handle_t bufferHandle, uint32_t width,
                                               uint32_t height, PixelFormat format,
                                               uint32_t layerCount, uint64_t usage,

--- a/libs/ui/include/ui/GraphicBuffer.h
+++ b/libs/ui/include/ui/GraphicBuffer.h
@@ -183,6 +183,8 @@ public:
     bool needsReallocation(uint32_t inWidth, uint32_t inHeight,
             PixelFormat inFormat, uint32_t inLayerCount, uint64_t inUsage);
 
+    int needConvertFormat();
+
     // For the following two lock functions, if bytesPerStride or bytesPerPixel
     // are unknown or variable, -1 will be returned
     status_t lock(uint32_t inUsage, void** vaddr, int32_t* outBytesPerPixel = nullptr,

--- a/libs/ui/include/ui/GraphicBufferMapper.h
+++ b/libs/ui/include/ui/GraphicBufferMapper.h
@@ -71,6 +71,8 @@ public:
 
     status_t freeBuffer(buffer_handle_t handle);
 
+    int needConvertFormat(buffer_handle_t handle);
+
     void getTransportSize(buffer_handle_t handle,
             uint32_t* outTransportNumFds, uint32_t* outTransportNumInts);
 


### PR DESCRIPTION
解决抖音/快手在AMD显卡环境下播放视频花屏等问题

由于AMD显卡环境要求256对齐，故使用BGRA中间层进行一次转换，先把YV12数据转换成BGRA数据，然后再把BGRA数据送至surfaceflinger参与合成显示