### PR TITLE
fix bilibili live yv12 video play abnormality in minigbm

### DIFF
--- a/libs/nativedisplay/surfacetexture/EGLConsumer.cpp
+++ b/libs/nativedisplay/surfacetexture/EGLConsumer.cpp
@@ -709,7 +709,8 @@ status_t EGLConsumer::EglImage::createIfNeeded(EGLDisplay eglDisplay, int video_
         if (video_width > 0) {
             sp<GraphicBuffer> graphicBuffer = mGraphicBuffer;
             if (graphicBuffer->getPixelFormat() == HAL_PIXEL_FORMAT_YV12) {
-                if (graphicBuffer->needConvertFormat()) {
+                // if (graphicBuffer->needConvertFormat())
+                {
                     void* data = nullptr;
                     int result = graphicBuffer->lock(GRALLOC_USAGE_SW_READ_OFTEN, &data);
                     if (result == 0 && data != nullptr) {
@@ -724,8 +725,7 @@ status_t EGLConsumer::EglImage::createIfNeeded(EGLDisplay eglDisplay, int video_
 
                         dst_gb = new GraphicBuffer(
                                     width, height, HAL_PIXEL_FORMAT_BGRA_8888,
-                                    GRALLOC_USAGE_HW_TEXTURE | GRALLOC_USAGE_HW_RENDER
-                                        | GRALLOC_USAGE_PRIVATE_0);
+                                    GRALLOC_USAGE_HW_TEXTURE | GRALLOC_USAGE_HW_RENDER);
 
                         void* dst_data = nullptr;
                         int dst_result = dst_gb->lock(GRALLOC_USAGE_SW_WRITE_OFTEN, &dst_data);


### PR DESCRIPTION
解决minigbm下B站直播页面出现马赛克的问题

- B站的yv12数据是由系统解码器产生，minigbm中仅对非512对齐的buf进行标记，故surfacetexture中对yv12均进行格式转换